### PR TITLE
Fix typo in Apache License detection

### DIFF
--- a/{{ cookiecutter.formula_name }}-formula/LICENSE
+++ b/{{ cookiecutter.formula_name }}-formula/LICENSE
@@ -1,4 +1,4 @@
-{% if cookiecutter.license == 'Apache Software license 2.0' %}
+{% if cookiecutter.license == 'Apache Software License 2.0' %}
    Copyright (c) {{ cookiecutter.year }} {{ cookiecutter.owner }}
 
    Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
A typo in the detection of the Apache License selection, changed "l" by "L"
