### PR TITLE
Updated Vagrantfile to support multiple distros

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -8,7 +8,7 @@
     "version": "201602",
     "owner": ["Massachusetts Institute of Technology", "SaltStack Formulas"],
     "license": ["MIT", "BSD-3", "GNU GPL v3.0", "Apache Software License 2.0"],
-    "vagrant_box": ["centos/7", "debian/wheezy64", "debian/jessie64", "ubuntu/trusty64", "ubuntu/vivid4"],
+    "vagrant_box": ["multi", "centos/7", "debian/wheezy64", "debian/jessie64", "ubuntu/trusty64", "ubuntu/xenial64"],
     "supported_os": "RedHat, CentOS, Ubuntu, Debian",
     "supported_os_family": "RedHat, Debian"
 }

--- a/{{ cookiecutter.formula_name }}-formula/Vagrantfile
+++ b/{{ cookiecutter.formula_name }}-formula/Vagrantfile
@@ -12,7 +12,22 @@ Vagrant.configure(2) do |config|
 
   # Every Vagrant development environment requires a box. You can search for
   # boxes at https://atlas.hashicorp.com/search.
+
+  {% if cookiecutter.vagrant_box == 'multi' %}
+  config.vm.define "debian" do |debian|
+    debian.vm.box = "debian/jessie64"
+  end
+
+  config.vm.define "centos" do |centos|
+    centos.vm.box = "centos/7"
+  end
+
+  config.vm.define "ubuntu" do |ubuntu|
+    ubuntu.vm.box = "ubuntu/trusty64"
+  end
+  {% else %}
   config.vm.box = "{{ cookiecutter.vagrant_box }}"
+  {% endif %}
 
   # Disable automatic box update checking. If you disable this, then
   # boxes will only be checked for updates when the user runs
@@ -38,6 +53,7 @@ Vagrant.configure(2) do |config|
   # the path on the guest to mount the folder. And the optional third
   # argument is a set of non-required options.
   # config.vm.synced_folder "../data", "/vagrant_data"
+  config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: ".git"
 
   # Provider-specific configuration so you can fine-tune various
   # backing providers for Vagrant. These expose provider-specific options.
@@ -70,8 +86,7 @@ Vagrant.configure(2) do |config|
   # SHELL
   config.vm.provision "shell", path: "scripts/vagrant_setup.sh"
   {% if cookiecutter.owner == "Massachusetts Institute of Technology" %}
-  config.vm.provision "shell", inline: "sudo apt-get install -y python-dev git python-pip"
-  config.vm.provision "shell", inline: "sudo pip install testinfra gitpython"
+  config.vm.provision "shell", path: "scripts/gitfs_deps.sh"
   {% endif %}
   config.vm.provision :salt do |salt|
     salt.minion_config = 'minion.conf'
@@ -81,6 +96,7 @@ Vagrant.configure(2) do |config|
     salt.colorize = true
     salt.verbose = true
   end
+  {% if cookiecutter.owner != "Massachusetts Institute of Technology" %}
   config.vm.provision "shell", path: "scripts/testinfra.sh"
-
+  {% endif %}
 end

--- a/{{ cookiecutter.formula_name }}-formula/scripts/gitfs_deps.sh
+++ b/{{ cookiecutter.formula_name }}-formula/scripts/gitfs_deps.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+if [ $(which apt-get) ];
+then
+    sudo apt-get update
+    PKG_MANAGER="apt-get"
+    PKGS="python-dev git"
+else
+    PKG_MANAGER="yum"
+    PKGS="python-devel git"
+fi
+
+sudo $PKG_MANAGER -y install $PKGS
+
+if [ $(which pip) ];
+then
+    echo ''
+else
+    curl -L "https://bootstrap.pypa.io/get-pip.py" > get_pip.py
+    sudo python get_pip.py
+    rm get_pip.py
+    sudo pip install gitpython
+fi


### PR DESCRIPTION
Updated the Vagrantfile to allow for running multiple distros out of the
box. This includes having a box definition for each of CentOS, Ubuntu,
and Debian, as well as writing a script to handle setup of the gitfs
system for mounting the mitodl/salt-extensions repo.
