### PR TITLE
Salt package manager support

### DIFF
--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,6 +12,6 @@
     "vagrant_box": ["multi", "centos/7", "debian/wheezy64", "debian/jessie64", "ubuntu/trusty64", "ubuntu/xenial64"],
     "supported_os": "RedHat, CentOS, Ubuntu, Debian",
     "supported_os_family": "RedHat, Debian",
-    "deploy_salt_package": ["False", "True"],
+    "deploy_as_salt_package": ["False", "True"],
     "_extensions": ["jinja2_time.TimeExtension"]
 }

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -12,5 +12,6 @@
     "vagrant_box": ["multi", "centos/7", "debian/wheezy64", "debian/jessie64", "ubuntu/trusty64", "ubuntu/xenial64"],
     "supported_os": "RedHat, CentOS, Ubuntu, Debian",
     "supported_os_family": "RedHat, Debian",
+    "deploy_salt_package": ["False", "True"],
     "_extensions": ["jinja2_time.TimeExtension"]
 }

--- a/{{ cookiecutter.formula_name }}-formula/Vagrantfile
+++ b/{{ cookiecutter.formula_name }}-formula/Vagrantfile
@@ -89,7 +89,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", path: "scripts/gitfs_deps.sh"
   {% endif %}
 
-  {% if cookiecutter.deploy_salt_packages == "True" %}
+  {% if cookiecutter.deploy_as_salt_package == "True" %}
   #set everything up, but don't run highstate yet.
   config.vm.provision :salt do |salt|
     salt.minion_config = 'minion.conf'
@@ -100,7 +100,7 @@ Vagrant.configure(2) do |config|
     salt.verbose = true
   end
 
-  #configure the spm packages
+  #configure spm packages
   spm_remote_url = ENV['SPM_REMOTE_URL']
   config.vm.provision "shell", path: "scripts/spm.sh", env: {"SPM_REMOTE_URL" => spm_remote_url}
 

--- a/{{ cookiecutter.formula_name }}-formula/Vagrantfile
+++ b/{{ cookiecutter.formula_name }}-formula/Vagrantfile
@@ -87,7 +87,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", path: "scripts/vagrant_setup.sh"
   {% if cookiecutter.owner == "Massachusetts Institute of Technology" %}
   config.vm.provision "shell", path: "scripts/gitfs_deps.sh"
-  {% endif %}
+  {% endif -%}
 
   {% if cookiecutter.deploy_as_salt_package == "True" %}
   #set everything up, but don't run highstate yet.
@@ -103,9 +103,9 @@ Vagrant.configure(2) do |config|
   #configure spm packages
   spm_remote_url = ENV['SPM_REMOTE_URL']
   config.vm.provision "shell", path: "scripts/spm.sh", env: {"SPM_REMOTE_URL" => spm_remote_url}
+  {% endif -%}
 
-  #now run highstate.
-  {% endif %}
+  #run highstate
   config.vm.provision :salt do |salt|
     salt.minion_config = 'minion.conf'
     salt.bootstrap_options = '-U -Z'
@@ -114,7 +114,8 @@ Vagrant.configure(2) do |config|
     salt.colorize = true
     salt.verbose = true
   end
-  {% if cookiecutter.owner != "Massachusetts Institute of Technology" %}
+
+  {% if cookiecutter.owner != "Massachusetts Institute of Technology" -%}
   config.vm.provision "shell", path: "scripts/testinfra.sh"
   {% endif %}
 end

--- a/{{ cookiecutter.formula_name }}-formula/Vagrantfile
+++ b/{{ cookiecutter.formula_name }}-formula/Vagrantfile
@@ -88,6 +88,24 @@ Vagrant.configure(2) do |config|
   {% if cookiecutter.owner == "Massachusetts Institute of Technology" %}
   config.vm.provision "shell", path: "scripts/gitfs_deps.sh"
   {% endif %}
+
+  {% if cookiecutter.deploy_salt_packages == "True" %}
+  #set everything up, but don't run highstate yet.
+  config.vm.provision :salt do |salt|
+    salt.minion_config = 'minion.conf'
+    salt.bootstrap_options = '-U -Z'
+    salt.masterless = true
+    salt.run_highstate = false
+    salt.colorize = true
+    salt.verbose = true
+  end
+
+  #configure the spm packages
+  spm_remote_url = ENV['SPM_REMOTE_URL']
+  config.vm.provision "shell", path: "scripts/spm.sh", env: {"SPM_REMOTE_URL" => spm_remote_url}
+
+  #now run highstate.
+  {% endif %}
   config.vm.provision :salt do |salt|
     salt.minion_config = 'minion.conf'
     salt.bootstrap_options = '-U -Z'

--- a/{{ cookiecutter.formula_name }}-formula/minion.conf
+++ b/{{ cookiecutter.formula_name }}-formula/minion.conf
@@ -1,21 +1,19 @@
 file_client: local
 
-{% if cookiecutter.deploy_as_salt_package == "True" %}
+{% if cookiecutter.deploy_as_salt_package == "True" -%}
 file_roots:
   base:
     - /srv/salt
     - /srv/spm/salt
-{% endif %}
+{% endif -%}
 
-fileserver_backend:
 {% if cookiecutter.owner == "Massachusetts Institute of Technology" %}
+fileserver_backend:
   - git
-{% endif %}
   - roots
 
-{% if cookiecutter.owner == "Massachusetts Institute of Technology" %}
 gitfs_provider: gitpython
 gitfs_remotes:
   - https://github.com/mitodl/salt-extensions:
       - root: extensions
-{% endif %}
+{% endif -%}

--- a/{{ cookiecutter.formula_name }}-formula/minion.conf
+++ b/{{ cookiecutter.formula_name }}-formula/minion.conf
@@ -1,12 +1,20 @@
 file_client: local
 
+{% if cookiecutter.deploy_salt_packages == "True" %}
+file_roots:
+  base:
+    - /srv/salt
+    - /srv/spm/salt
+{% endif %}
+
 fileserver_backend:
+{% if cookiecutter.owner == "Massachusetts Institute of Technology" %}
   - git
+{% endif %}
   - roots
 
-gitfs_provider: gitpython
-
 {% if cookiecutter.owner == "Massachusetts Institute of Technology" %}
+gitfs_provider: gitpython
 gitfs_remotes:
   - https://github.com/mitodl/salt-extensions:
       - root: extensions

--- a/{{ cookiecutter.formula_name }}-formula/minion.conf
+++ b/{{ cookiecutter.formula_name }}-formula/minion.conf
@@ -1,6 +1,6 @@
 file_client: local
 
-{% if cookiecutter.deploy_salt_packages == "True" %}
+{% if cookiecutter.deploy_as_salt_package == "True" %}
 file_roots:
   base:
     - /srv/salt

--- a/{{ cookiecutter.formula_name }}-formula/scripts/spm.sh
+++ b/{{ cookiecutter.formula_name }}-formula/scripts/spm.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+if [ "$(ls /vagrant)" ]
+then
+    SRCDIR=/vagrant
+else
+    SRCDIR=/home/vagrant/sync
+fi
+#make the repository configurations
+sudo mkdir -p /etc/salt/spm.repos.d
+if [[ ! -z "$SPM_REMOTE_URL" ]] ; then
+    echo "\
+remote_repo:
+  url: $SPM_REMOTE_URL" | sudo tee /etc/salt/spm.repos.d/spm_remote.repo
+fi
+
+#clean the build area
+if [ -d /srv/spm_build ]; then
+    sudo rm -rf /srv/spm_build
+fi
+#clean the installation cache
+if [ -d /var/cache/salt/spm/ ]; then
+sudo rm -rf /var/cache/salt/spm
+fi
+#clean the installed package area
+if [ -d /srv/spm ]; then
+sudo rm -rf /srv/spm
+fi
+
+#build the project
+sudo spm build $SRCDIR
+sudo spm update_repo
+#use a local install to prevent https://github.com/saltstack/salt/issues/39266
+#said issues will only occur when: 
+# - more than one repo is configured, and
+# - the same package name appears in both
+latest=$(ls -t /srv/spm_build/{{ cookiecutter.formula_name }}*.spm | head -n1)
+sudo spm local install -y -f $latest
+
+
+if ls /srv/spm/pillar/*.orig > /dev/null 2>&1; then
+#set up pillar top file
+echo "\
+base:
+  '*':" | sudo tee /srv/pillar/top.sls
+
+    for pillar in $(ls /srv/spm/pillar/*.orig); do
+    newbase=$(basename $pillar)
+    newbase=${newbase/.orig/}
+    cp -f $pillar /srv/pillar/$newbase
+    newbase=${newbase/.sls/}
+    echo "    - $newbase" | sudo tee -a /srv/pillar/top.sls
+    done
+fi

--- a/{{ cookiecutter.formula_name }}-formula/scripts/vagrant_setup.sh
+++ b/{{ cookiecutter.formula_name }}-formula/scripts/vagrant_setup.sh
@@ -9,7 +9,7 @@ fi
 sudo mkdir -p /srv/salt
 sudo mkdir -p /srv/pillar
 sudo mkdir -p /srv/formulas
-{% if cookiecutter.deploy_salt_packages == "True" %}
+{% if cookiecutter.deploy_as_salt_package == "True" %}
 sudo mkdir -p /var/cache/salt/master
 {% else %}
 sudo cp $SRCDIR/pillar.example /srv/pillar/pillar.sls

--- a/{{ cookiecutter.formula_name }}-formula/scripts/vagrant_setup.sh
+++ b/{{ cookiecutter.formula_name }}-formula/scripts/vagrant_setup.sh
@@ -9,10 +9,14 @@ fi
 sudo mkdir -p /srv/salt
 sudo mkdir -p /srv/pillar
 sudo mkdir -p /srv/formulas
+{% if cookiecutter.deploy_salt_packages == "True" %}
+sudo mkdir -p /var/cache/salt/master
+{% else %}
 sudo cp $SRCDIR/pillar.example /srv/pillar/pillar.sls
 sudo cp -r $SRCDIR/{{ cookiecutter.formula_name }} /srv/salt
 echo "\
 base:
   '*':
     - pillar" | sudo tee /srv/pillar/top.sls
+{% endif %}
 sudo cp $SRCDIR/salt-top.example /srv/salt/top.sls


### PR DESCRIPTION
The development experience with Vagrant is different when using packages, because you can't just sync files anymore. For that reason I put the salt package manager functionality behind a cookiecutter property called deploy_as_salt_package. This preserves backwards compatibility with the exception of the extra prompt. 